### PR TITLE
Fixed a compile error when it doesn't have _DIRENT_HAVE_D_NAMLEN macro.

### DIFF
--- a/dc_indexer.c
+++ b/dc_indexer.c
@@ -90,8 +90,12 @@ int dc_index(char *datapath, char *indexpath)
         
 #ifdef DEBUG
         elog(NOTICE, "-FILE NAME: %s", dirent->d_name);
+#ifdef _DIRENT_HAVE_D_NAMLEN
         elog(NOTICE, "-FILE NAME LEN: %d", dirent->d_namlen);
-#endif
+#else
+        elog(NOTICE, "-FILE NAME LEN: %d", strlen(dirent->d_name));
+#endif /* _DIRENT_HAVE_D_NAMLEN */
+#endif /* DEBUG */
         
         /* 
          * concat path and fname to full file name


### PR DESCRIPTION
I have a compile error under Red Hat Enterprise Linux 5.7.
